### PR TITLE
build(ci): add notifications for audit trail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ licenses:
     - 'google-gdk-license-.+'
 script:
      - ./gradlew connectedCheck -PdisablePreDex -PtaskThreads=1 -PandroidThread=1
+     
+notifications:
+  webhooks: https://fathomless-fjord-24024.herokuapp.com/notify


### PR DESCRIPTION
This Travis CI bot can notify you about builds of your repositories on Telegram.

https://storebot.me/bot/travisci_build_bot